### PR TITLE
BUG FIX: relink after player solid state changes

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -162,16 +162,19 @@ void CheckTiming(void)
 			// ok we are detect - player lagged, so do something, effects is exception
 			if (firstTime)
 			{
-				if (timing_players_action & TA_INVINCIBLE)
-				{
-					p->k_timingTakedmg = p->s.v.takedamage;
-					p->k_timingSolid = p->s.v.solid;
-					p->k_timingMovetype = p->s.v.movetype;
-					p->s.v.takedamage = 0;
-					p->s.v.solid = 0;
-					p->s.v.movetype = 0;
-					SetVector(p->s.v.velocity, 0, 0, 0); // speed is zeroed and not restored
-				}
+                if (timing_players_action & TA_INVINCIBLE)
+                {
+                    p->k_timingTakedmg = p->s.v.takedamage;
+                    p->k_timingSolid = p->s.v.solid;
+                    p->k_timingMovetype = p->s.v.movetype;
+                    p->s.v.takedamage = 0;
+                    p->s.v.solid = 0;
+                    p->s.v.movetype = 0;
+                    SetVector(p->s.v.velocity, 0, 0, 0); // speed is zeroed and not restored
+					
+                    // Relink after solid change to avoid stale area list membership
+                    setorigin(p, PASSVEC3(p->s.v.origin));
+                }
 			}
 
 		}
@@ -3193,7 +3196,7 @@ void ClientDisconnect(void)
 
 void BackFromLag(void)
 {
-	int timing_players_action = TA_ALL & (int)cvar("timing_players_action");
+    int timing_players_action = TA_ALL & (int)cvar("timing_players_action");
 
 	self->k_timingWarnTime = 0;
 
@@ -3202,12 +3205,15 @@ void BackFromLag(void)
 		G_bprint(2, "%s %s\n", self->netname, redtext("is back from lag"));
 	}
 
-	if (timing_players_action & TA_INVINCIBLE)
-	{
-		self->s.v.takedamage = self->k_timingTakedmg;
-		self->s.v.solid = self->k_timingSolid;
-		self->s.v.movetype = self->k_timingMovetype;
-	}
+    if (timing_players_action & TA_INVINCIBLE)
+    {
+        self->s.v.takedamage = self->k_timingTakedmg;
+        self->s.v.solid = self->k_timingSolid;
+        self->s.v.movetype = self->k_timingMovetype;
+
+        // Relink after solid change to ensure proper area list placement
+        setorigin(self, PASSVEC3(self->s.v.origin));
+    }
 }
 
 #define S_AXE	( 1<<0 )

--- a/src/match.c
+++ b/src/match.c
@@ -2039,11 +2039,14 @@ void standby_think(void)
 					setnowep(p);
 				}
 
-				p->s.v.takedamage = 0;
-				p->s.v.solid = 0;
-				p->s.v.movetype = 0;
-				p->s.v.modelindex = 0;
-				p->model = "";
+                p->s.v.takedamage = 0;
+                p->s.v.solid = 0;
+                p->s.v.movetype = 0;
+                p->s.v.modelindex = 0;
+                p->model = "";
+				
+                // Relink after solid change to keep area lists consistent
+                setorigin(p, PASSVEC3(p->s.v.origin));
 			}
 		}
 	}
@@ -2569,12 +2572,15 @@ void StopTimer(int removeDemo)
 
 		for (p = world; (p = find_plr(p));)
 		{
-			setfullwep(p);
+            setfullwep(p);
 
-			p->s.v.takedamage = DAMAGE_AIM;
-			p->s.v.solid = SOLID_SLIDEBOX;
-			p->s.v.movetype = MOVETYPE_WALK;
-			setmodel(p, "progs/player.mdl");
+            p->s.v.takedamage = DAMAGE_AIM;
+            p->s.v.solid = SOLID_SLIDEBOX;
+            p->s.v.movetype = MOVETYPE_WALK;
+            setmodel(p, "progs/player.mdl");
+
+            // Relink after solid change so players are returned to the correct list
+            setorigin(p, PASSVEC3(p->s.v.origin));
 		}
 	}
 


### PR DESCRIPTION
Fixes server crash that occurs after player solid state changes, such as when using /leavemealone.