### PR TITLE
Fix faulty condition

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -905,15 +905,15 @@ void SM_PrepareMap(void)
 				continue;
 			}
 			else if (streq(p->classname, "weapon_rocketlauncher") &&
-				!FrogbotItemPickupBonus() &&
-				(disallowed_weapons & IT_ROCKET_LAUNCHER))
+				(!FrogbotItemPickupBonus() ||
+				(disallowed_weapons & IT_ROCKET_LAUNCHER)))
 			{
 				soft_ent_remove(p);
 				continue;
 			}
 			else if (streq(p->classname, "weapon_lightning") &&
-				!FrogbotItemPickupBonus() &&
-				(disallowed_weapons & IT_LIGHTNING))
+				(!FrogbotItemPickupBonus() ||
+				(disallowed_weapons & IT_LIGHTNING)))
 			{
 				soft_ent_remove(p);
 				continue;


### PR DESCRIPTION
When the item pickup bonus was introduced, the condition that removed rocket launcher and lightning gun entities for dmm >= 4 was modified incorrectly. This caused the weapons to be left on the map in cases where they shouldn't have.