### PR TITLE
Make easier bot skill toggleable

### DIFF
--- a/include/fb_globals.h
+++ b/include/fb_globals.h
@@ -368,6 +368,7 @@ int FrogbotHealth(void);
 int FrogbotWeapon(void);
 int FrogbotQuadMultiplier(void);
 qbool FrogbotItemPickupBonus(void);
+qbool FrogbotEasySkillMode(void);
 
 // botthink.qc
 void SetMarker(gedict_t *client, gedict_t *marker);
@@ -409,6 +410,7 @@ qbool HasSavedMarker(void);
 #define FB_CVAR_QUAD_MULTIPLIER   "k_fb_quad_multiplier"
 #define FB_CVAR_ITEM_PICKUP_BONUS "k_fb_item_pickup_bonus"
 #define FB_CVAR_NEW_MOVE_SCALE    "k_fb_new_move_scale"
+#define FB_CVAR_EASY_SKILL_MODE   "k_fb_easy_skill_mode"
 
 void BotsFireLogic(void);
 

--- a/src/bot_botimp.c
+++ b/src/bot_botimp.c
@@ -153,11 +153,7 @@ void RegisterSkillVariables(void)
 	RegisterCvar(FB_CVAR_OPPONENT_MIDAIR_VOLATILITY_INCREASE);
 }
 
-void setLgcModeSkillAttributes(int skill, int aimskill) {
-	// Keep LGC bot skill attributes separate so we can change
-	// general skill attributes without affecting LGC mode, so players
-	// can still play LGC mode on same terms as old records.
-
+void setSkillAttributes(int skill, int aimskill) {
 	// Old frogbot settings (items generally)
 	cvar_fset(FB_CVAR_ACCURACY, 45 - min(skill, 10) * 2.25);
 	cvar_fset(FB_CVAR_DODGEFACTOR, RangeOverSkill(skill, 0.0f, 1.0f));
@@ -208,7 +204,7 @@ void setLgcModeSkillAttributes(int skill, int aimskill) {
 	cvar_fset(FB_CVAR_MISSILEDODGE_TIME, RangeOverSkill(skill, 1.0f, 0.5f));
 }
 
-void setSkillAttributes(int skill, int aimskill) {
+void setSkillAttributesEasySkillMode(int skill, int aimskill) {
 	// Old frogbot settings (items generally)
 	cvar_fset(FB_CVAR_ACCURACY, 45 - min(skill, 10) * 2.25);
 	cvar_fset(FB_CVAR_DODGEFACTOR, RangeOverSkill(skill, 0.0f, 1.0f));
@@ -269,10 +265,13 @@ qbool SetAttributesBasedOnSkill(int skill)
 	skill = bound(MIN_FROGBOT_SKILL, skill, MAX_FROGBOT_SKILL);
 	aimskill = bound(MIN_FROGBOT_SKILL, skill, MAX_FROGBOT_AIM_SKILL);
 
-	if (lgc_enabled()) {
-		G_bprint(2, "LGC mode enabled - using legacy bot skill attributes.\n");
-		setLgcModeSkillAttributes(skill, aimskill);
-	} else {
+	if (FrogbotEasySkillMode())
+	{
+		G_bprint(2, "%s\n", redtext("Using easy bot skill mode"));
+		setSkillAttributesEasySkillMode(skill, aimskill);
+	} else
+	{
+		G_bprint(2, "%s\n", redtext("Using default bot skill mode"));
 		setSkillAttributes(skill, aimskill);
 	}
 

--- a/src/bot_commands.c
+++ b/src/bot_commands.c
@@ -135,6 +135,11 @@ qbool FrogbotItemPickupBonus(void)
 	return tot_mode_enabled() && (qbool)cvar(FB_CVAR_ITEM_PICKUP_BONUS);
 }
 
+qbool FrogbotEasySkillMode(void)
+{
+	return (qbool)cvar(FB_CVAR_EASY_SKILL_MODE);
+}
+
 static team_t* AddTeamToList(int *teamsFound, char *team, int topColor, int bottomColor)
 {
 	int i;
@@ -2281,6 +2286,19 @@ static void FrogbotsSetItemPickupBonus(void)
 		(int)cvar(FB_CVAR_ITEM_PICKUP_BONUS) ? redtext("on") : redtext("off"));
 }
 
+static void FrogbotsSetEasySkillMode(void)
+{
+	if (!bots_enabled())
+	{
+		G_sprint(self, 2, "Bots are disabled by the server.\n");
+		return;
+	}
+
+	cvar_fset(FB_CVAR_EASY_SKILL_MODE, !cvar(FB_CVAR_EASY_SKILL_MODE));
+	G_sprint(self, 2, "easy skill mode changed to %s\n",
+		(int)cvar(FB_CVAR_EASY_SKILL_MODE) ? redtext("on") : redtext("off"));
+}
+
 typedef struct frogbot_cmd_s
 {
 	char *name;
@@ -2302,7 +2320,8 @@ static frogbot_cmd_t std_commands[] =
 		{ "breakondeath", FrogbotsSetBreakOnDeath, "Automatically break when you die" },
 		{ "togglequad", FrogbotsToggleQuad, "Toggle quad damage" },
 		{ "quadmultiplier", FrogbotsSetQuadMultiplier, "Set quad damage multiplier" },
-		{ "itempickupbonus", FrogbotsSetItemPickupBonus, "Toggle item pickup bonus" }};
+		{ "itempickupbonus", FrogbotsSetItemPickupBonus, "Toggle item pickup bonus" },
+		{ "easyskillmode", FrogbotsSetEasySkillMode, "Toggle easy skill mode" }};
 
 static frogbot_cmd_t editor_commands[] =
 	{

--- a/src/match.c
+++ b/src/match.c
@@ -1846,6 +1846,12 @@ void PrintCountdown(int seconds)
 
 	}
 
+	if (CountBots() >= 1)
+	{
+		strlcat(text, va("Bot Skill Mode %11s\n",
+				redtext(FrogbotEasySkillMode() ? "easy" : "default")), sizeof(text));
+	}
+
 	if (matchtag[0])
 	{
 		strlcat(text, va("\nmatchtag %s\n\n\n", matchtag), sizeof(text));

--- a/src/world.c
+++ b/src/world.c
@@ -1070,6 +1070,7 @@ void FirstFrame(void)
 	RegisterCvarEx(FB_CVAR_QUAD_MULTIPLIER, "4");
 	RegisterCvarEx(FB_CVAR_ITEM_PICKUP_BONUS, "0");
 	RegisterCvarEx(FB_CVAR_NEW_MOVE_SCALE, "0");
+	RegisterCvarEx(FB_CVAR_EASY_SKILL_MODE, "0");
 
 	for (i = 0; i < MAX_CLIENTS; i++)
 	{


### PR DESCRIPTION
This fixes the breaking changes that were introduced by this commit: https://github.com/QW-Group/ktx/commit/55497e87822af62a7fe34575254c30ec2a052f6f

An attempt to fix it was done here, but it only corrected the behaviour for LGC mode:
https://github.com/QW-Group/ktx/commit/234dd4cf5a0ffba1c0b5b4baaf22bea6deffed79

Players are used to playing bots in several other modes as well, so instead of limiting the fix, this change makes it possible to toggle whether you want to play with the easier bot skill or not.