### PR TITLE
Allow pause without matchtag if k_pausewithoutmatchtag is set

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -5976,10 +5976,10 @@ qbool PlayerCanPause(gedict_t *p)
 	qbool playerCanPause = false;
 	char *matchtag = ezinfokey(world, "matchtag");
 
-	// Check for matchtag. If it is set, it is an official (probably), so pause might be allowed.
-	if ((NULL != matchtag) && matchtag[0])
+	// Check for matchtag, OR allow if k_pausewithoutmatchtag is set.
+	if (cvar("k_pausewithoutmatchtag") || ((matchtag != NULL) && matchtag[0]))
 	{
-		// matchtag is found. Let's see if the player can still pause.
+		// Let's see if the player can still pause.
 		if (p->k_pauseRequests > 0)
 		{
 			p->k_pauseRequests--;

--- a/src/world.c
+++ b/src/world.c
@@ -786,6 +786,7 @@ void FirstFrame(void)
 
 	RegisterCvar("k_noitems");
 	RegisterCvarEx("k_leavemealone", "1");
+	RegisterCvarEx("k_pausewithoutmatchtag", "0");
 
 	RegisterCvar("k_random_maplist"); // select random map from k_ml_XXX variables.
 


### PR DESCRIPTION
Previously, players could only pause if a matchtag was set. This change adds support for the cvar k_pausewithoutmatchtag. When enabled, the check for matchtag is skipped, and players can use their available pause requests regardless of whether the game has a matchtag.