### PR TITLE
Allow spawn markers to be shown during games

### DIFF
--- a/include/g_local.h
+++ b/include/g_local.h
@@ -1282,10 +1282,15 @@ extern int maxPlayerCount;
 
 qbool AllowMonster(gedict_t *e);
 
+#define SPAWN_SHOW_DISABLED 0
+#define SPAWN_SHOW_PREWAR 1
+#define SPAWN_SHOW_MATCH 2
+
 #define SPAWNICIDE_DISABLED 0
 #define SPAWNICIDE_PREWAR 1
 #define SPAWNICIDE_MATCH 2
 
+int SpawnShowStatus(void);
 int SpawnicideStatus(void);
 void SpawnicideEnable(void);
 void SpawnicideDisable(void);

--- a/src/commands.c
+++ b/src/commands.c
@@ -2695,22 +2695,42 @@ void ToggleRespawns(void)
 	G_bprint(2, "%s\n", respawn_model_name(k_spw));
 }
 
+int SpawnShowStatus(void)
+{
+	return (int)cvar("k_spm_show");
+}
+
 void ToggleSpawnPoints(void)
 {
+	int spawn_show = cvar("k_spm_show");
+
 	if (match_in_progress)
 	{
 		return;
 	}
 
-	cvar_toggle_msg(self, "k_spm_show", redtext("visible spawn points"));
+	spawn_show++;
 
-	if (cvar("k_spm_show"))
+	if (spawn_show > SPAWN_SHOW_MATCH)
 	{
-		ShowSpawnPoints();
+		spawn_show = SPAWN_SHOW_DISABLED;
 	}
-	else
+
+	cvar_set("k_spm_show", va("%d", spawn_show));
+	switch (spawn_show)
 	{
-		HideSpawnPoints();
+		case SPAWNICIDE_DISABLED:
+			HideSpawnPoints();
+			G_sprint(self, 2, "Visible spawns %s\n", redtext("off"));
+			break;
+		case SPAWNICIDE_PREWAR:
+			ShowSpawnPoints();
+			G_sprint(self, 2, "Visible spawns %s\n", redtext("prewar"));
+			break;
+		case SPAWNICIDE_MATCH:
+			ShowSpawnPoints();
+			G_sprint(self, 2, "Visible spawns %s\n", redtext("match"));
+			break;
 	}
 }
 

--- a/src/hoonymode.c
+++ b/src/hoonymode.c
@@ -855,7 +855,7 @@ static void HM_deselect_spawn(gedict_t *spawn)
 	}
 
 	// If showing all spawns, just remove the glow.  otherwise remove the marker.
-	if (cvar("k_spm_show"))
+	if (SpawnShowStatus() > SPAWN_SHOW_DISABLED)
 	{
 		spawn->wizard->s.v.effects = (int)spawn->wizard->s.v.effects & ~effects;
 	}

--- a/src/match.c
+++ b/src/match.c
@@ -1258,7 +1258,10 @@ void StartMatch(void)
 
 	SM_PrepareMap(); // remove/add some items from map regardind with dmm and game mode
 
-	HideSpawnPoints();
+	if (SpawnShowStatus() != SPAWN_SHOW_MATCH)
+	{
+		HideSpawnPoints();
+	}
 
 	if (SpawnicideStatus() == SPAWNICIDE_MATCH)
 	{

--- a/src/race.c
+++ b/src/race.c
@@ -530,7 +530,7 @@ void race_shutdown(char *msg)
 	race_cancel(true, "%s", msg);
 	race_remove_ent();
 	race_unready_all();
-	if (cvar("k_spm_show"))
+	if (SpawnShowStatus() > SPAWN_SHOW_DISABLED)
 	{
 		ShowSpawnPoints();
 	}

--- a/src/world.c
+++ b/src/world.c
@@ -701,7 +701,7 @@ void Customize_Maps(void)
 		SpawnicideEnable();
 	}
 
-	if (cvar("k_spm_show"))
+	if (SpawnShowStatus() > SPAWN_SHOW_DISABLED)
 	{
 		ShowSpawnPoints();
 	}


### PR DESCRIPTION
k_spm_show can now be set to 2, which makes spawn markers render even after the match has started.

The variable can also be cycled by running the spawn_show command as a connected client.